### PR TITLE
[BUGFIX] Remove whitespaces from searialized data and increase it's maximum size

### DIFF
--- a/Classes/Backend/DataHandler/MetaDataHandler.php
+++ b/Classes/Backend/DataHandler/MetaDataHandler.php
@@ -13,7 +13,7 @@ class MetaDataHandler implements SingletonInterface
     {
         $queueDataFactory = new QueueDataFactory();
         $job = new Job();
-        $serializedData = json_decode($fieldArray['serialized_data']);
+        $serializedData = json_decode($fieldArray['serialized_data'] ?? '');
         if (!$serializedData) {
             $job->setSerializedData('');
         } else {

--- a/Classes/Backend/DataHandler/MetaDataHandler.php
+++ b/Classes/Backend/DataHandler/MetaDataHandler.php
@@ -13,11 +13,11 @@ class MetaDataHandler implements SingletonInterface
     {
         $queueDataFactory = new QueueDataFactory();
         $job = new Job();
-        $job->setSerializedData($fieldArray['serialized_data'] ?? '');
+        $job->setSerializedData(json_encode(json_decode($fieldArray['serialized_data'])) ?? '');
         $job->setHash($fieldArray['hash'] ?? '');
 
         if ($queueDataFactory->updateLegacyJobData($job)) {
-            $fieldArray['serialized_data'] = $job->getSerializedData();
+            $fieldArray['serialized_data'] = json_encode(json_decode($job->getSerializedData()));
         }
 
         $fieldArray['route'] = $queueDataFactory->getJobRoute($job);

--- a/Classes/Backend/DataHandler/MetaDataHandler.php
+++ b/Classes/Backend/DataHandler/MetaDataHandler.php
@@ -13,7 +13,12 @@ class MetaDataHandler implements SingletonInterface
     {
         $queueDataFactory = new QueueDataFactory();
         $job = new Job();
-        $job->setSerializedData(json_encode(json_decode($fieldArray['serialized_data'])) ?? '');
+        $serializedData = json_decode($fieldArray['serialized_data']);
+        if (!$serializedData) {
+            $job->setSerializedData('');
+        } else {
+            $job->setSerializedData(json_encode($serializedData));
+        }
         $job->setHash($fieldArray['hash'] ?? '');
 
         if ($queueDataFactory->updateLegacyJobData($job)) {

--- a/Classes/Domain/Model/Queue/Job.php
+++ b/Classes/Domain/Model/Queue/Job.php
@@ -191,12 +191,12 @@ class Job extends AbstractEntity implements JobInterface
 
     public function setData(array $data)
     {
-        $serializedData = json_encode($data, JSON_PRETTY_PRINT);
+        $serializedData = json_encode($data);
         if ($serializedData === false) {
             $this->setStatus(QueueInterface::STATUS_FAILED);
             $this->setStatusMessage('data encoding failed [' . json_last_error() . ']: "' . json_last_error_msg() . '"');
 
-            $serializedData = json_encode($data, JSON_PRETTY_PRINT | JSON_INVALID_UTF8_SUBSTITUTE);
+            $serializedData = json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE);
             if ($serializedData === false) {
                 if (isset($data['submission']['configuration'])) {
                     // remove "configuration" since print_r is not able to print big data sets completely

--- a/Classes/Form/Element/JsonFieldElement.php
+++ b/Classes/Form/Element/JsonFieldElement.php
@@ -2,10 +2,7 @@
 
 namespace Mediatis\Formrelay\Form\Element;
 
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\StringUtility;
-
-class JsonFieldElement extends \TYPO3\CMS\Backend\Form\Element\AbstractFormElement
+class JsonFieldElement extends \TYPO3\CMS\Backend\Form\Element\TextElement
 {
     /**
      * Render textarea and use whitespaces to format JSON
@@ -13,55 +10,11 @@ class JsonFieldElement extends \TYPO3\CMS\Backend\Form\Element\AbstractFormEleme
     public function render()
     {
         $parameterArray = $this->data['parameterArray'];
-        $cols = $parameterArray['fieldConf']['config']['parameters']['cols'];
-        $rows = $parameterArray['fieldConf']['config']['parameters']['rows'];
-        $readOnly = $parameterArray['fieldConf']['config']['parameters']['readOnly'];
-
-        $fieldInformationResult = $this->renderFieldInformation();
-        $fieldInformationHtml = $fieldInformationResult['html'];
-        $resultArray = $this->mergeChildReturnIntoExistingResult($this->initializeResultArray(), $fieldInformationResult, false);
-
-        $fieldId = StringUtility::getUniqueId('formengine-textarea-');
-
-        $attributes = [
-            'id' => $fieldId,
-            'name' => htmlspecialchars($parameterArray['itemFormElName']),
-            'cols' => $cols,
-            'rows' => $rows,
-            'readonly' => $readOnly,
-            'data-formengine-input-name' => htmlspecialchars($parameterArray['itemFormElName'])
-        ];
-
-        $classes = [
-            'form-control',
-            't3js-formengine-textarea',
-            'formengine-textarea',
-        ];
-        // If value can be decoded into json, we encode it with JSON_PRETTY_PRINT, else use the raw value.
+        // If value can be decoded into json, we encode it again with JSON_PRETTY_PRINT
         $itemValue = json_decode($parameterArray['itemFormElValue']);
-        if (!$itemValue) {
-            $itemValue = $parameterArray['itemFormElValue'];
-        } else {
-            $itemValue = json_encode($itemValue, JSON_PRETTY_PRINT);
+        if ($itemValue) {
+            $this->data['parameterArray']['itemFormElValue'] = json_encode($itemValue, JSON_PRETTY_PRINT);
         }
-        $attributes['class'] = implode(' ', $classes);
-
-        $html = [];
-        $html[] = '<div class="formengine-field-item t3js-formengine-field-item">';
-        $html[] = $fieldInformationHtml;
-        $html[] = '<div class="form-wizards-wrap">';
-        $html[] = '<div class="form-wizards-element">';
-        $html[] = '<div class="form-control-wrap">';
-        $html[] = '<textarea ' . GeneralUtility::implodeAttributes($attributes, true) . '>';
-        $html[] = $itemValue;
-        $html[] = '</textarea>';
-        $html[] = '</div>';
-        $html[] = '</div>';
-        $html[] = '</div>';
-        $html[] = '</div>';
-        $resultArray['html'] = implode(LF, $html);
-
-        return $resultArray;
+        return parent::render();
     }
-
 }

--- a/Classes/Form/Element/JsonFieldElement.php
+++ b/Classes/Form/Element/JsonFieldElement.php
@@ -37,7 +37,13 @@ class JsonFieldElement extends \TYPO3\CMS\Backend\Form\Element\AbstractFormEleme
             't3js-formengine-textarea',
             'formengine-textarea',
         ];
-        $itemValue = $parameterArray['itemFormElValue'];
+        // If value can be decoded into json, we encode it with JSON_PRETTY_PRINT, else use the raw value.
+        $itemValue = json_decode($parameterArray['itemFormElValue']);
+        if (!$itemValue) {
+            $itemValue = $parameterArray['itemFormElValue'];
+        } else {
+            $itemValue = json_encode($itemValue, JSON_PRETTY_PRINT);
+        }
         $attributes['class'] = implode(' ', $classes);
 
         $html = [];
@@ -47,7 +53,7 @@ class JsonFieldElement extends \TYPO3\CMS\Backend\Form\Element\AbstractFormEleme
         $html[] = '<div class="form-wizards-element">';
         $html[] = '<div class="form-control-wrap">';
         $html[] = '<textarea ' . GeneralUtility::implodeAttributes($attributes, true) . '>';
-        $html[] = json_encode(json_decode($itemValue), JSON_PRETTY_PRINT);
+        $html[] = $itemValue;
         $html[] = '</textarea>';
         $html[] = '</div>';
         $html[] = '</div>';

--- a/Classes/Form/Element/JsonFieldElement.php
+++ b/Classes/Form/Element/JsonFieldElement.php
@@ -2,16 +2,17 @@
 
 namespace Mediatis\Formrelay\Form\Element;
 
-class JsonFieldElement extends \TYPO3\CMS\Backend\Form\Element\TextElement
+use TYPO3\CMS\Backend\Form\Element\TextElement;
+
+class JsonFieldElement extends TextElement
 {
     /**
      * Render textarea and use whitespaces to format JSON
      */
     public function render()
     {
-        $parameterArray = $this->data['parameterArray'];
         // If value can be decoded into json, we encode it again with JSON_PRETTY_PRINT
-        $itemValue = json_decode($parameterArray['itemFormElValue']);
+        $itemValue = json_decode($this->data['parameterArray']['itemFormElValue']);
         if ($itemValue) {
             $this->data['parameterArray']['itemFormElValue'] = json_encode($itemValue, JSON_PRETTY_PRINT);
         }

--- a/Classes/Form/Element/JsonFieldElement.php
+++ b/Classes/Form/Element/JsonFieldElement.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Mediatis\Formrelay\Form\Element;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\StringUtility;
+
+class JsonFieldElement extends \TYPO3\CMS\Backend\Form\Element\AbstractFormElement
+{
+    /**
+     * Render textarea and use whitespaces to format JSON
+     */
+    public function render()
+    {
+        $parameterArray = $this->data['parameterArray'];
+        $cols = $parameterArray['fieldConf']['config']['parameters']['cols'];
+        $rows = $parameterArray['fieldConf']['config']['parameters']['rows'];
+        $readOnly = $parameterArray['fieldConf']['config']['parameters']['readOnly'];
+
+        $fieldInformationResult = $this->renderFieldInformation();
+        $fieldInformationHtml = $fieldInformationResult['html'];
+        $resultArray = $this->mergeChildReturnIntoExistingResult($this->initializeResultArray(), $fieldInformationResult, false);
+
+        $fieldId = StringUtility::getUniqueId('formengine-textarea-');
+
+        $attributes = [
+            'id' => $fieldId,
+            'name' => htmlspecialchars($parameterArray['itemFormElName']),
+            'cols' => $cols,
+            'rows' => $rows,
+            'readonly' => $readOnly,
+            'data-formengine-input-name' => htmlspecialchars($parameterArray['itemFormElName'])
+        ];
+
+        $classes = [
+            'form-control',
+            't3js-formengine-textarea',
+            'formengine-textarea',
+        ];
+        $itemValue = $parameterArray['itemFormElValue'];
+        $attributes['class'] = implode(' ', $classes);
+
+        $html = [];
+        $html[] = '<div class="formengine-field-item t3js-formengine-field-item">';
+        $html[] = $fieldInformationHtml;
+        $html[] = '<div class="form-wizards-wrap">';
+        $html[] = '<div class="form-wizards-element">';
+        $html[] = '<div class="form-control-wrap">';
+        $html[] = '<textarea ' . GeneralUtility::implodeAttributes($attributes, true) . '>';
+        $html[] = json_encode(json_decode($itemValue), JSON_PRETTY_PRINT);
+        $html[] = '</textarea>';
+        $html[] = '</div>';
+        $html[] = '</div>';
+        $html[] = '</div>';
+        $html[] = '</div>';
+        $resultArray['html'] = implode(LF, $html);
+
+        return $resultArray;
+    }
+
+}

--- a/Configuration/TCA/tx_formrelay_domain_model_queue_job.php
+++ b/Configuration/TCA/tx_formrelay_domain_model_queue_job.php
@@ -120,10 +120,13 @@ $GLOBALS['TCA']['tx_formrelay_domain_model_queue_job'] = [
             'exclude' => 1,
             'label' => $ll . 'tx_formrelay_domain_model_queue_job.serialized_data',
             'config' => [
-                'type' => 'text',
-                'cols' => 40,
-                'rows' => 15,
-                'readOnly' => $readOnly,
+                'type' => 'user',
+                'renderType' => 'formrelayJsonFieldElement',
+                'parameters' => [
+                    'cols' => 40,
+                    'rows' => 15,
+                    'readOnly' => $readOnly,
+                ],
             ],
         ],
     ],

--- a/Configuration/TCA/tx_formrelay_domain_model_queue_job.php
+++ b/Configuration/TCA/tx_formrelay_domain_model_queue_job.php
@@ -122,11 +122,9 @@ $GLOBALS['TCA']['tx_formrelay_domain_model_queue_job'] = [
             'config' => [
                 'type' => 'user',
                 'renderType' => 'formrelayJsonFieldElement',
-                'parameters' => [
-                    'cols' => 40,
-                    'rows' => 15,
-                    'readOnly' => $readOnly,
-                ],
+                'cols' => 40,
+                'rows' => 15,
+                'readOnly' => $readOnly,
             ],
         ],
     ],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -52,4 +52,12 @@ module.tx_form.settings.yamlConfigurations {
     ];
 
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] = \Mediatis\Formrelay\Backend\DataHandler\MetaDataHandler::class;
+
+    // Add textarea with built-in json formatting
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1640091726] = [
+        'nodeName' => 'formrelayJsonFieldElement',
+        'priority' => 40,
+        'class' => \Mediatis\Formrelay\Form\Element\JsonFieldElement::class,
+    ];
+
 })();

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -10,7 +10,7 @@ CREATE TABLE tx_formrelay_domain_model_queue_job (
   status int(11) unsigned DEFAULT 0,
   skipped tinyint(4) unsigned DEFAULT '0' NOT NULL,
   status_message text DEFAULT '',
-  serialized_data text DEFAULT '',
+  serialized_data mediumtext DEFAULT '',
 
   changed int(11) unsigned DEFAULT '0' NOT NULL,
   created int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
Currently serialized_data only allows 65k characters of text (this inclued whitespaces). If form submit data contains more text (either due to submitted text or very long formhandler config), it will be ommited and the data is lost.
To remove the need of whitespaces i added a custom TCA form field that does the JSON pretty formatting by it self. 
The datahandler handles the removal of whitespaces before saving to the database.
Just in case, i changed the field type of serialized_data to mediumtext, which allows up to 16MB of data.